### PR TITLE
change version number to comply with version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='rsocket',
-    version='0.2.0',
+    version='1.0.0',
     description='Python RSocket library',
     url='https://github.com/RSocket/rsocket-py',
     author='Vijayan Rajan',


### PR DESCRIPTION
version 1.0 is the least accepted version by RSocket java SDK.