### PR TITLE
Websocket - fix closing websocket server/client and task cancellation handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,9 @@ async def pipe_factory_websocket(aiohttp_raw_server, unused_tcp_port, client_arg
     test_overrides = {'keep_alive_period': timedelta(minutes=20)}
     client_arguments = client_arguments or {}
     client_arguments.update(test_overrides)
+
     async with websocket_client('http://localhost:{}'.format(unused_tcp_port),
                                 **client_arguments) as client:
-        yield servers[0], client
+        server = servers[0]
+        yield server, client
+        server.close()

--- a/tests/rsocket/test_lease.py
+++ b/tests/rsocket/test_lease.py
@@ -12,17 +12,32 @@ from rsocket.request_handler import BaseRequestHandler
 
 class PeriodicalLeasePublisher(SingleLeasePublisher):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._lease_task = None
+
     async def subscribe(self, subscriber: Subscriber):
-        asyncio.ensure_future(self._subscribe_loop(subscriber))
+        self._lease_task = asyncio.create_task(self._subscribe_loop(subscriber))
 
     async def _subscribe_loop(self, subscriber: Subscriber):
-        while True:
-            await asyncio.sleep(self.wait_between_leases.total_seconds())
+        try:
+            while True:
+                await asyncio.sleep(self.wait_between_leases.total_seconds())
 
-            await subscriber.on_next(DefinedLease(
-                maximum_request_count=self.maximum_request_count,
-                maximum_lease_time=self.maximum_lease_time
-            ))
+                await subscriber.on_next(DefinedLease(
+                    maximum_request_count=self.maximum_request_count,
+                    maximum_lease_time=self.maximum_lease_time
+                ))
+        except asyncio.CancelledError:
+            pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self._lease_task is not None:
+            self._lease_task.cancel()
+            await self._lease_task
 
 
 class TestFeatureLease:
@@ -52,27 +67,28 @@ class TestFeatureLease:
                                           b'meta: ' + request.metadata))
                 return future
 
-        async with lazy_pipe(client_arguments={'honor_lease': True,
-                                               'handler_factory': Handler,
-                                               'lease_publisher': PeriodicalLeasePublisher(
-                                                   maximum_request_count=2,
-                                                   maximum_lease_time=timedelta(seconds=3),
-                                                   wait_between_leases=timedelta(seconds=2)
-                                               )},
-                             server_arguments={'honor_lease': True,
-                                               'handler_factory': Handler,
-                                               'lease_publisher': PeriodicalLeasePublisher(
-                                                   maximum_request_count=2,
-                                                   maximum_lease_time=timedelta(seconds=3),
-                                                   wait_between_leases=timedelta(seconds=2)
-                                               )}) as (server, client):
-            for x in range(3):
-                response = await client.request_response(Payload(b'dog', b'cat'))
-                assert response == Payload(b'data: dog', b'meta: cat')
+        async with PeriodicalLeasePublisher(
+                maximum_request_count=2,
+                maximum_lease_time=timedelta(seconds=3),
+                wait_between_leases=timedelta(seconds=2)) as client_leases:
+            async with PeriodicalLeasePublisher(
+                    maximum_request_count=2,
+                    maximum_lease_time=timedelta(seconds=3),
+                    wait_between_leases=timedelta(seconds=2)) as server_leases:
+                async with lazy_pipe(
+                        client_arguments={'honor_lease': True,
+                                          'handler_factory': Handler,
+                                          'lease_publisher': client_leases},
+                        server_arguments={'honor_lease': True,
+                                          'handler_factory': Handler,
+                                          'lease_publisher': server_leases}) as (server, client):
+                    for x in range(3):
+                        response = await client.request_response(Payload(b'dog', b'cat'))
+                        assert response == Payload(b'data: dog', b'meta: cat')
 
-            for x in range(3):
-                response = await server.request_response(Payload(b'dog', b'cat'))
-                assert response == Payload(b'data: dog', b'meta: cat')
+                    for x in range(3):
+                        response = await server.request_response(Payload(b'dog', b'cat'))
+                        assert response == Payload(b'data: dog', b'meta: cat')
 
     async def test_request_response_with_lease_too_many_requests(self, lazy_pipe):
         class Handler(BaseRequestHandler):


### PR DESCRIPTION
Websocket - fix closing websocket server/client and task cancellation handling

### Motivation:

errors in test log show websocket sessions not closing

### Modifications:

correctly close websocket sessions for server and client

### Result:

less errors in test log and correctly closed websocket sessions for server and client
