### PR TITLE
Metadata push api added to rsocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ are in java to show compatibility with a different implementation.
     - [X] Fire and forget
     - [X] Response
     - [X] Stream
-    - [X] Cahnnel
-- [ ] Features
+    - [X] Channel
     - [X] Metadata push
+- [ ] Features
     - [X] Keepalive / Max server life
     - [X] Lease
     - [ ] Resume

--- a/rsocket/frame.py
+++ b/rsocket/frame.py
@@ -295,6 +295,7 @@ class KeepAliveFrame(Frame):
 
     def __init__(self, data=b'', metadata=b''):
         super().__init__(Type.KEEPALIVE)
+        self.stream_id = CONNECTION_STREAM_ID
         self.flags_respond = False
         self.data = data
         self.metadata = metadata

--- a/rsocket/frame.py
+++ b/rsocket/frame.py
@@ -485,6 +485,7 @@ class MetadataPushFrame(Frame):
 
     def __init__(self):
         super().__init__(Type.METADATA_PUSH)
+        self.stream_id = CONNECTION_STREAM_ID
         self.metadata_only = True
         self.flags_metadata = True
 

--- a/rsocket/rsocket.py
+++ b/rsocket/rsocket.py
@@ -417,6 +417,11 @@ class RSocket:
         self._streams[stream] = requester
         return requester
 
+    def metadata_push(self, metadata: bytes):
+        frame = MetadataPushFrame()
+        frame.metadata = metadata
+        self.send_frame(frame)
+
     def _is_frame_allowed_to_send(self, frame: Frame) -> bool:
         if isinstance(frame, (RequestResponseFrame,
                               RequestStreamFrame,

--- a/rsocket/rsocket.py
+++ b/rsocket/rsocket.py
@@ -319,7 +319,6 @@ class RSocket:
 
     def _send_new_keepalive(self, data: bytes = b''):
         frame = KeepAliveFrame()
-        frame.stream_id = CONNECTION_STREAM_ID
         frame.flags_respond = True
         frame.data = data
         self.send_frame(frame)

--- a/rsocket/rx_support/rx_rsocket_client.py
+++ b/rsocket/rx_support/rx_rsocket_client.py
@@ -26,6 +26,9 @@ class RxRSocketClient:
     def fire_and_forget(self, request: Payload):
         self._rsocket_client.fire_and_forget(request)
 
+    def metadata_push(self, metadata: bytes):
+        self._rsocket_client.metadata_push(metadata)
+
     def _to_subject(self, publisher: Publisher) -> Subject:
         subject = Subject()
         publisher.subscribe(RxSubscriber(subject))

--- a/tests/rsocket/test_metadata_push.py
+++ b/tests/rsocket/test_metadata_push.py
@@ -1,0 +1,29 @@
+import asyncio
+from typing import Optional
+
+from rsocket.payload import Payload
+from rsocket.request_handler import BaseRequestHandler
+from rsocket.rsocket_client import RSocketClient
+from rsocket.rsocket_server import RSocketServer
+
+
+async def test_metadata_push(pipe):
+    metadata_push_received = asyncio.Event()
+    received_payload: Optional[Payload] = None
+
+    class Handler(BaseRequestHandler):
+        async def on_metadata_push(self, payload: Payload):
+            nonlocal received_payload
+            received_payload = payload
+            metadata_push_received.set()
+
+    server: RSocketServer = pipe[0]
+    client: RSocketClient = pipe[1]
+    server.set_handler_using_factory(Handler)
+
+    client.metadata_push(b'cat')
+
+    await metadata_push_received.wait()
+
+    assert received_payload.data == None
+    assert received_payload.metadata == b'cat'


### PR DESCRIPTION
Metadata push api added to rsocket

### Motivation:

Required support for metadata push in the python api

### Modifications:

Metadata push api added to rsocket and rx rsocket client wrapper

### Result:

Metadata push api added to rsocket
