### PR TITLE
Send payload on setup and handle errors

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -1,13 +1,13 @@
 import asyncio
 import logging
 
-from reactivestreams.subscriber import Subscriber
+from reactivestreams.subscriber import DefaultSubscriber
 from rsocket.payload import Payload
 from rsocket.rsocket_client import RSocketClient
 from rsocket.transports.tcp import TransportTCP
 
 
-class StreamSubscriber(Subscriber):
+class StreamSubscriber(DefaultSubscriber):
 
     def on_next(self, value, is_complete=False):
         logging.info('RS: {}'.format(value))

--- a/rsocket/payload.py
+++ b/rsocket/payload.py
@@ -17,3 +17,6 @@ class Payload:
 
     def __eq__(self, other):
         return self.data == other.data and self.metadata == other.metadata
+
+    def __repr__(self):
+        return "Payload({}, {})".format(self.data, self.metadata)

--- a/rsocket/request_handler.py
+++ b/rsocket/request_handler.py
@@ -6,7 +6,9 @@ from typing import Tuple
 from reactivestreams.publisher import Publisher
 from reactivestreams.subscriber import Subscriber
 from reactivestreams.subscription import DefaultSubscription
+from rsocket.error_codes import ErrorCode
 from rsocket.extensions.composite_metadata import CompositeMetadata
+from rsocket.logger import logger
 from rsocket.payload import Payload
 
 
@@ -48,6 +50,10 @@ class RequestHandler(metaclass=ABCMeta):
     async def request_stream(self, payload: Payload) -> Publisher:
         ...
 
+    @abstractmethod
+    async def on_error(self, error_code: ErrorCode, payload: Payload):
+        ...
+
     def _parse_composite_metadata(self, metadata: bytes) -> CompositeMetadata:
         composite_metadata = CompositeMetadata()
         composite_metadata.parse(metadata)
@@ -83,3 +89,6 @@ class BaseRequestHandler(RequestHandler):
 
     async def request_stream(self, payload: Payload) -> Publisher:
         return self.UnimplementedPublisher()
+
+    async def on_error(self, error_code: ErrorCode, payload: Payload):
+        logger().error('Error: %s, %s', error_code, payload)

--- a/rsocket/request_handler.py
+++ b/rsocket/request_handler.py
@@ -20,9 +20,9 @@ class RequestHandler(metaclass=ABCMeta):
 
     @abstractmethod
     async def on_setup(self,
-                       data_encoding: bytes,
-                       metadata_encoding: bytes,
-                       payload: Payload):
+                 data_encoding: bytes,
+                 metadata_encoding: bytes,
+                 payload: Payload):
         ...
 
     @abstractmethod
@@ -68,9 +68,9 @@ class BaseRequestHandler(RequestHandler):
             subscriber.on_error(RuntimeError('Not implemented'))
 
     async def on_setup(self,
-                       data_encoding: bytes,
-                       metadata_encoding: bytes,
-                       payload: Payload):
+                 data_encoding: bytes,
+                 metadata_encoding: bytes,
+                 payload: Payload):
         """Nothing to do on setup by default"""
 
     async def request_channel(self, payload: Payload) -> Tuple[Publisher, Subscriber]:

--- a/rsocket/request_handler.py
+++ b/rsocket/request_handler.py
@@ -19,7 +19,8 @@ class RequestHandler(metaclass=ABCMeta):
     @abstractmethod
     async def on_setup(self,
                        data_encoding: bytes,
-                       metadata_encoding: bytes):
+                       metadata_encoding: bytes,
+                       payload: Payload):
         ...
 
     @abstractmethod
@@ -62,7 +63,8 @@ class BaseRequestHandler(RequestHandler):
 
     async def on_setup(self,
                        data_encoding: bytes,
-                       metadata_encoding: bytes):
+                       metadata_encoding: bytes,
+                       payload: Payload):
         """Nothing to do on setup by default"""
 
     async def request_channel(self, payload: Payload) -> Tuple[Publisher, Subscriber]:

--- a/rsocket/routing/routing_request_handler.py
+++ b/rsocket/routing/routing_request_handler.py
@@ -40,16 +40,16 @@ class RoutingRequestHandler(BaseRequestHandler):
 
     # noinspection PyAttributeOutsideInit
     async def on_setup(self,
-                       data_encoding: bytes,
-                       metadata_encoding: bytes,
-                       payload: Payload):
+                 data_encoding: bytes,
+                 metadata_encoding: bytes,
+                 payload: Payload):
 
         if metadata_encoding != WellKnownMimeTypes.MESSAGE_RSOCKET_COMPOSITE_METADATA.value.name:
             raise Exception('Setup frame did not specify composite metadata. required for routing handler')
         else:
             self.data_encoding = data_encoding
             self.metadata_encoding = metadata_encoding
-            await super().on_setup(data_encoding, metadata_encoding)
+            await super().on_setup(data_encoding, metadata_encoding, payload)
 
     async def request_channel(self, payload: Payload) -> Tuple[Publisher, Subscriber]:
         try:

--- a/rsocket/routing/routing_request_handler.py
+++ b/rsocket/routing/routing_request_handler.py
@@ -41,7 +41,8 @@ class RoutingRequestHandler(BaseRequestHandler):
     # noinspection PyAttributeOutsideInit
     async def on_setup(self,
                        data_encoding: bytes,
-                       metadata_encoding: bytes):
+                       metadata_encoding: bytes,
+                       payload: Payload):
 
         if metadata_encoding != WellKnownMimeTypes.MESSAGE_RSOCKET_COMPOSITE_METADATA.value.name:
             raise Exception('Setup frame did not specify composite metadata. required for routing handler')

--- a/rsocket/rsocket.py
+++ b/rsocket/rsocket.py
@@ -194,7 +194,8 @@ class RSocket:
         handler = self._handler
         try:
             await handler.on_setup(frame.data_encoding,
-                                   frame.metadata_encoding)
+                                   frame.metadata_encoding,
+                                   Payload(frame.data, frame.metadata))
         except Exception as exception:
             self.send_error(frame.stream_id, exception)
 

--- a/rsocket/rsocket.py
+++ b/rsocket/rsocket.py
@@ -56,7 +56,8 @@ class RSocket:
                  data_encoding: Union[bytes, WellKnownMimeTypes] = WellKnownMimeTypes.APPLICATION_JSON,
                  metadata_encoding: Union[bytes, WellKnownMimeTypes] = WellKnownMimeTypes.APPLICATION_JSON,
                  keep_alive_period: timedelta = timedelta(milliseconds=500),
-                 max_lifetime_period: timedelta = timedelta(minutes=10)
+                 max_lifetime_period: timedelta = timedelta(minutes=10),
+                 setup_payload: Optional[Payload] = None
                  ):
 
         self._transport = transport
@@ -65,6 +66,7 @@ class RSocket:
         self._honor_lease = honor_lease
         self._max_lifetime_period = max_lifetime_period
         self._keep_alive_period = keep_alive_period
+        self._setup_payload = setup_payload
 
         self._data_encoding = self._ensure_encoding_name(data_encoding)
         self._metadata_encoding = self._ensure_encoding_name(metadata_encoding)
@@ -435,13 +437,21 @@ class RSocket:
 
         return True
 
-    def _create_setup_frame(self, data_encoding: bytes, metadata_encoding: bytes) -> SetupFrame:
+    def _create_setup_frame(self,
+                            data_encoding: bytes,
+                            metadata_encoding: bytes,
+                            payload: Optional[Payload] = None) -> SetupFrame:
         setup = SetupFrame()
         setup.flags_lease = self._honor_lease
         setup.keep_alive_milliseconds = to_milliseconds(self._keep_alive_period)
         setup.max_lifetime_milliseconds = to_milliseconds(self._max_lifetime_period)
         setup.data_encoding = data_encoding
         setup.metadata_encoding = metadata_encoding
+
+        if payload is not None:
+            setup.data = payload.data
+            setup.metadata = payload.metadata
+
         return setup
 
     @abc.abstractmethod

--- a/rsocket/rsocket.py
+++ b/rsocket/rsocket.py
@@ -164,7 +164,7 @@ class RSocket:
         pass
 
     async def handle_error(self, frame: ErrorFrame):
-        ...
+        await self._handler.on_error(frame.error_code, Payload(frame.data, frame.metadata))
 
     async def handle_keep_alive(self, frame: KeepAliveFrame):
         logger().debug('%s: Received keepalive', self._log_identifier())

--- a/rsocket/rsocket_client.py
+++ b/rsocket/rsocket_client.py
@@ -55,7 +55,9 @@ class RSocketClient(RSocket):
         return 1
 
     def connect(self):
-        self.send_frame(self._create_setup_frame(self._data_encoding, self._metadata_encoding))
+        self.send_frame(self._create_setup_frame(self._data_encoding,
+                                                 self._metadata_encoding,
+                                                 self._setup_payload))
 
         if self._honor_lease:
             self._subscribe_to_lease_publisher()

--- a/rsocket/rsocket_client.py
+++ b/rsocket/rsocket_client.py
@@ -7,6 +7,7 @@ from reactivestreams.publisher import Publisher
 from rsocket.error_codes import ErrorCode
 from rsocket.extensions.mimetypes import WellKnownMimeTypes
 from rsocket.frame import ErrorFrame
+from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
 from rsocket.request_handler import RequestHandler
 from rsocket.rsocket import RSocket, _not_provided
@@ -25,7 +26,8 @@ class RSocketClient(RSocket):
                  data_encoding: Union[bytes, WellKnownMimeTypes] = WellKnownMimeTypes.APPLICATION_JSON,
                  metadata_encoding: Union[bytes, WellKnownMimeTypes] = WellKnownMimeTypes.APPLICATION_JSON,
                  keep_alive_period: timedelta = timedelta(milliseconds=500),
-                 max_lifetime_period: timedelta = timedelta(minutes=10)
+                 max_lifetime_period: timedelta = timedelta(minutes=10),
+                 setup_payload: Optional[Payload] = None
                  ):
         self._is_server_alive = True
         self._update_last_keepalive()
@@ -39,7 +41,8 @@ class RSocketClient(RSocket):
                          data_encoding=data_encoding,
                          metadata_encoding=metadata_encoding,
                          keep_alive_period=keep_alive_period,
-                         max_lifetime_period=max_lifetime_period)
+                         max_lifetime_period=max_lifetime_period,
+                         setup_payload=setup_payload)
 
     def _log_identifier(self) -> str:
         return 'client'

--- a/tests/rsocket/test_authentication.py
+++ b/tests/rsocket/test_authentication.py
@@ -1,6 +1,8 @@
 import asyncio
-from asyncio import Future
+from asyncio import Future, Event
+from typing import Optional
 
+from rsocket.error_codes import ErrorCode
 from rsocket.exceptions import RSocketRejected, RSocketApplicationError
 from rsocket.extensions.authentication import AuthenticationSimple
 from rsocket.extensions.authentication_types import WellKnownAuthenticationTypes
@@ -58,7 +60,7 @@ async def test_authentication_frame_simple():
     assert serialized_data == data
 
 
-async def test_authentication_on_setup(lazy_pipe):
+async def test_authentication_success_on_setup(lazy_pipe):
     class Handler(BaseRequestHandler):
         def __init__(self, socket):
             super().__init__(socket)
@@ -87,3 +89,45 @@ async def test_authentication_on_setup(lazy_pipe):
             client_arguments={'setup_payload': Payload(metadata=composite(authenticate_simple('user', '12345')))},
             server_arguments={'handler_factory': Handler}) as (server, client):
         result = await client.request_response(Payload(b'request'))
+
+        assert result.data == b'response'
+
+
+async def test_authentication_failure_on_setup(lazy_pipe):
+    received_error_event = Event()
+    received_error: Optional[tuple] = None
+
+    class ServerHandler(BaseRequestHandler):
+        def __init__(self, socket):
+            super().__init__(socket)
+            self._authenticated = False
+
+        async def on_setup(self,
+                           data_encoding: bytes,
+                           metadata_encoding: bytes,
+                           payload: Payload):
+            composite_metadata = self._parse_composite_metadata(payload.metadata)
+            authentication: AuthenticationSimple = composite_metadata.items[0].authentication
+            if authentication.username != b'user' or authentication.password != b'12345':
+                raise RSocketApplicationError('Authentication error')
+
+            self._authenticated = True
+
+    class ClientHandler(BaseRequestHandler):
+        async def on_error(self, error_code: ErrorCode, payload: Payload):
+            nonlocal received_error
+            received_error = (error_code, payload)
+            received_error_event.set()
+
+    async with lazy_pipe(
+            client_arguments={
+                'handler_factory': ClientHandler,
+                'setup_payload': Payload(metadata=composite(authenticate_simple('user', 'wrong_password')))
+            },
+            server_arguments={
+                'handler_factory': ServerHandler
+            }) as (server, client):
+        await received_error_event.wait()
+
+        assert received_error[0] == ErrorCode.APPLICATION_ERROR
+        assert received_error[1] == Payload(b'Authentication error', b'')


### PR DESCRIPTION
Send payload on setup and handle errors

### Motivation:

Added ability to send payload on setup (was missing, found due to requirement to work against a spring rsocket example server)

### Modifications:

* added sending payload on setup frame
* added error handler on RequestHandler abstract class and calling it on error frame
* added logging about sending setup frame
* added tests for sending setup frame with authentication metadata
* fixed failing client example

### Result:

better rsocket protocol support