### PR TITLE
Reconnect support

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -16,7 +16,7 @@ class StreamSubscriber(DefaultSubscriber):
 
 
 async def main():
-    connection = await asyncio.open_connection('localhost', 7000)
+    connection = await asyncio.open_connection('localhost', 6565)
 
     async with RSocketClient(single_transport_provider(TransportTCP(*connection))) as client:
         payload = Payload(b'%Y-%m-%d %H:%M:%S')

--- a/examples/client.py
+++ b/examples/client.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from reactivestreams.subscriber import DefaultSubscriber
+from rsocket.helpers import single_transport_provider
 from rsocket.payload import Payload
 from rsocket.rsocket_client import RSocketClient
 from rsocket.transports.tcp import TransportTCP
@@ -15,11 +16,9 @@ class StreamSubscriber(DefaultSubscriber):
 
 
 async def main():
-    async def transport_provider():
-        connection = await asyncio.open_connection('localhost', 7000)
-        yield TransportTCP(*connection)
+    connection = await asyncio.open_connection('localhost', 7000)
 
-    async with RSocketClient(transport_provider()) as client:
+    async with RSocketClient(single_transport_provider(TransportTCP(*connection))) as client:
         payload = Payload(b'%Y-%m-%d %H:%M:%S')
 
         async def run_request_response():

--- a/examples/client.py
+++ b/examples/client.py
@@ -15,9 +15,11 @@ class StreamSubscriber(DefaultSubscriber):
 
 
 async def main():
-    connection = await asyncio.open_connection('localhost', 6565)
+    async def transport_provider():
+        connection = await asyncio.open_connection('localhost', 7000)
+        yield TransportTCP(*connection)
 
-    async with RSocketClient(TransportTCP(*connection)) as client:
+    async with RSocketClient(transport_provider()) as client:
         payload = Payload(b'%Y-%m-%d %H:%M:%S')
 
         async def run_request_response():

--- a/examples/client_springboot.py
+++ b/examples/client_springboot.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from reactivestreams.subscriber import DefaultSubscriber
 from rsocket.extensions.helpers import composite, route, authenticate_simple
 from rsocket.extensions.mimetypes import WellKnownMimeTypes
+from rsocket.helpers import single_transport_provider
 from rsocket.payload import Payload
 from rsocket.rsocket_client import RSocketClient
 from rsocket.transports.tcp import TransportTCP
@@ -19,15 +20,13 @@ class StreamSubscriber(DefaultSubscriber):
 
 
 async def main():
-    async def transport_provider():
-        connection = await asyncio.open_connection('localhost', 7000)
-        yield TransportTCP(*connection)
+    connection = await asyncio.open_connection('localhost', 7000)
 
     setup_payload = Payload(
         data=str(uuid4()).encode(),
         metadata=composite(route('shell-client'), authenticate_simple('user', 'pass')))
 
-    async with RSocketClient(transport_provider(),
+    async with RSocketClient(single_transport_provider(TransportTCP(*connection)),
                              setup_payload=setup_payload,
                              metadata_encoding=WellKnownMimeTypes.MESSAGE_RSOCKET_COMPOSITE_METADATA):
         await asyncio.sleep(5)

--- a/examples/client_with_routing.py
+++ b/examples/client_with_routing.py
@@ -8,6 +8,7 @@ from reactivestreams.subscription import Subscription
 from rsocket.extensions.helpers import route, composite, authenticate_simple
 from rsocket.extensions.mimetypes import WellKnownMimeTypes
 from rsocket.fragment import Fragment
+from rsocket.helpers import single_transport_provider
 from rsocket.payload import Payload
 from rsocket.rsocket_client import RSocketClient
 from rsocket.streams.stream_from_async_generator import StreamFromAsyncGenerator
@@ -144,11 +145,9 @@ async def request_fragmented_stream(socket: RSocketClient):
 
 async def main():
 
-    async def transport_provider():
-        connection = await asyncio.open_connection('localhost', 6565)
-        yield TransportTCP(*connection)
+    connection = await asyncio.open_connection('localhost', 6565)
 
-    async with RSocketClient(transport_provider(),
+    async with RSocketClient(single_transport_provider(TransportTCP(*connection)),
                              metadata_encoding=WellKnownMimeTypes.MESSAGE_RSOCKET_COMPOSITE_METADATA) as client:
         await request_response(client)
         await request_stream(client)

--- a/examples/run_against_example_java_server.py
+++ b/examples/run_against_example_java_server.py
@@ -9,6 +9,7 @@ from reactivestreams.subscription import Subscription
 from rsocket.extensions.composite_metadata import CompositeMetadata
 from rsocket.extensions.mimetypes import WellKnownMimeTypes
 from rsocket.extensions.routing import RoutingMetadata
+from rsocket.helpers import single_transport_provider
 from rsocket.payload import Payload
 from rsocket.rsocket_client import RSocketClient
 from rsocket.transports.tcp import TransportTCP
@@ -33,11 +34,9 @@ async def main():
         def on_error(self, exception: Exception):
             completion_event.set()
 
-    async def transport_provider():
-        connection = await asyncio.open_connection('localhost', 6565)
-        yield TransportTCP(*connection)
+    connection = await asyncio.open_connection('localhost', 6565)
 
-    async with RSocketClient(transport_provider(),
+    async with RSocketClient(single_transport_provider(TransportTCP(*connection)),
                              metadata_encoding=WellKnownMimeTypes.MESSAGE_RSOCKET_COMPOSITE_METADATA.value.name,
                              data_encoding=WellKnownMimeTypes.APPLICATION_JSON.value.name) as client:
         metadata = CompositeMetadata()

--- a/examples/run_against_example_java_server.py
+++ b/examples/run_against_example_java_server.py
@@ -33,8 +33,11 @@ async def main():
         def on_error(self, exception: Exception):
             completion_event.set()
 
-    connection = await asyncio.open_connection('localhost', 6565)
-    async with RSocketClient(TransportTCP(*connection),
+    async def transport_provider():
+        connection = await asyncio.open_connection('localhost', 6565)
+        yield TransportTCP(*connection)
+
+    async with RSocketClient(transport_provider(),
                              metadata_encoding=WellKnownMimeTypes.MESSAGE_RSOCKET_COMPOSITE_METADATA.value.name,
                              data_encoding=WellKnownMimeTypes.APPLICATION_JSON.value.name) as client:
         metadata = CompositeMetadata()

--- a/rsocket/awaitable/awaitable_rsocket.py
+++ b/rsocket/awaitable/awaitable_rsocket.py
@@ -47,8 +47,8 @@ class AwaitableRSocket:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._rsocket.__aexit__(exc_type, exc_val, exc_tb)
 
-    def connect(self):
-        return self._rsocket.connect()
+    async def connect(self):
+        return await self._rsocket.connect()
 
     def close(self):
         self._rsocket.close()

--- a/rsocket/exceptions.py
+++ b/rsocket/exceptions.py
@@ -60,3 +60,7 @@ class RSocketFrameFragmentDifferentType(RSocketError):
 
 class RSocketTransportError(RSocketError):
     pass
+
+
+class RSocketNoAvailableTransport(RSocketError):
+    pass

--- a/rsocket/exceptions.py
+++ b/rsocket/exceptions.py
@@ -34,11 +34,11 @@ class RSocketStreamAllocationFailure(RSocketError):
     pass
 
 
-class RSocketValueErrorException(RSocketError):
+class RSocketValueError(RSocketError):
     pass
 
 
-class RSocketProtocolException(RSocketError):
+class RSocketProtocolError(RSocketError):
     def __init__(self, error_code: ErrorCode, data: Optional[str] = None):
         self.error_code = error_code
         self.data = data
@@ -47,7 +47,7 @@ class RSocketProtocolException(RSocketError):
         return 'RSocket error %s(%s): "%s"' % (self.error_code.name, self.error_code.value, self.data or '')
 
 
-class RSocketStreamIdInUse(RSocketProtocolException):
+class RSocketStreamIdInUse(RSocketProtocolError):
 
     def __init__(self, stream_id: int):
         super().__init__(ErrorCode.REJECTED)
@@ -55,4 +55,8 @@ class RSocketStreamIdInUse(RSocketProtocolException):
 
 
 class RSocketFrameFragmentDifferentType(RSocketError):
+    pass
+
+
+class RSocketTransportError(RSocketError):
     pass

--- a/rsocket/helpers.py
+++ b/rsocket/helpers.py
@@ -60,3 +60,7 @@ def wrap_transport_exception():
         yield
     except Exception as exception:
         raise RSocketTransportError from exception
+
+
+def single_transport_provider(transport):
+    yield transport

--- a/rsocket/helpers.py
+++ b/rsocket/helpers.py
@@ -62,5 +62,5 @@ def wrap_transport_exception():
         raise RSocketTransportError from exception
 
 
-def single_transport_provider(transport):
+async def single_transport_provider(transport):
     yield transport

--- a/rsocket/helpers.py
+++ b/rsocket/helpers.py
@@ -1,20 +1,22 @@
 import asyncio
-from typing import Optional
+from contextlib import contextmanager
+from typing import Optional, Any
 
 from reactivestreams.publisher import DefaultPublisher
 from reactivestreams.subscriber import Subscriber
 from reactivestreams.subscription import DefaultSubscription
+from rsocket.exceptions import RSocketTransportError
 from rsocket.frame import Frame
 from rsocket.payload import Payload
 
 _default = object()
 
 
-def create_future(payload: Optional[Payload] = _default) -> asyncio.Future:
+def create_future(value: Optional[Any] = _default) -> asyncio.Future:
     future = asyncio.get_event_loop().create_future()
 
-    if payload is not _default:
-        future.set_result(payload)
+    if value is not _default:
+        future.set_result(value)
 
     return future
 
@@ -50,3 +52,11 @@ class WellKnownType:
 
     def __hash__(self):
         return hash((self.id, self.name))
+
+
+@contextmanager
+def wrap_transport_exception():
+    try:
+        yield
+    except Exception as exception:
+        raise RSocketTransportError from exception

--- a/rsocket/load_balancer/load_balancer_rsocket.py
+++ b/rsocket/load_balancer/load_balancer_rsocket.py
@@ -30,14 +30,14 @@ class LoadBalancerRSocket(RSocket):
     def metadata_push(self, metadata: bytes):
         self._select_client().metadata_push(metadata)
 
-    def connect(self):
-        self._strategy.connect()
+    async def connect(self):
+        await self._strategy.connect()
 
     async def close(self):
         await self._strategy.close()
 
     async def __aenter__(self) -> RSocket:
-        self._strategy.connect()
+        await self._strategy.connect()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/rsocket/load_balancer/load_balancer_strategy.py
+++ b/rsocket/load_balancer/load_balancer_strategy.py
@@ -9,7 +9,7 @@ class LoadBalancerStrategy(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def connect(self):
+    async def connect(self):
         ...
 
     @abc.abstractmethod

--- a/rsocket/load_balancer/random_client.py
+++ b/rsocket/load_balancer/random_client.py
@@ -20,9 +20,9 @@ class LoadBalancerRandom(LoadBalancerStrategy):
         random_client_id = random.randint(0, len(self._pool))
         return self._pool[random_client_id]
 
-    def connect(self):
+    async def connect(self):
         if self._auto_connect:
-            [client.connect() for client in self._pool]
+            [await client.connect() for client in self._pool]
 
     async def close(self):
         if self._auto_close:

--- a/rsocket/load_balancer/round_robin.py
+++ b/rsocket/load_balancer/round_robin.py
@@ -20,9 +20,9 @@ class LoadBalancerRoundRobin(LoadBalancerStrategy):
         self._current_index = (self._current_index + 1) % len(self._pool)
         return client
 
-    def connect(self):
+    async def connect(self):
         if self._auto_connect:
-            [client.connect() for client in self._pool]
+            [await client.connect() for client in self._pool]
 
     async def close(self):
         if self._auto_close:

--- a/rsocket/request_handler.py
+++ b/rsocket/request_handler.py
@@ -58,7 +58,11 @@ class RequestHandler(metaclass=ABCMeta):
     @abstractmethod
     async def on_keepalive_timeout(self,
                                    time_since_last_keepalive: timedelta,
-                                   cancel_all_streams: Callable):
+                                   rsocket):
+        ...
+
+    @abstractmethod
+    async def on_connection_lost(self, rsocket):
         ...
 
     def _parse_composite_metadata(self, metadata: bytes) -> CompositeMetadata:
@@ -92,6 +96,9 @@ class BaseRequestHandler(RequestHandler):
 
     async def on_error(self, error_code: ErrorCode, payload: Payload):
         logger().error('Error: %s, %s', error_code, payload)
+
+    async def on_connection_lost(self, rsocket):
+        pass
 
     async def on_keepalive_timeout(self,
                                    time_since_last_keepalive: timedelta,

--- a/rsocket/request_handler.py
+++ b/rsocket/request_handler.py
@@ -2,7 +2,7 @@ import asyncio
 from abc import ABCMeta, abstractmethod
 from asyncio import Future
 from datetime import timedelta
-from typing import Tuple, Optional, Callable
+from typing import Tuple, Optional
 
 from reactivestreams.publisher import Publisher
 from reactivestreams.subscriber import Subscriber
@@ -62,7 +62,7 @@ class RequestHandler(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    async def on_connection_lost(self, rsocket):
+    async def on_connection_lost(self, rsocket, exception):
         ...
 
     def _parse_composite_metadata(self, metadata: bytes) -> CompositeMetadata:
@@ -97,10 +97,10 @@ class BaseRequestHandler(RequestHandler):
     async def on_error(self, error_code: ErrorCode, payload: Payload):
         logger().error('Error: %s, %s', error_code, payload)
 
-    async def on_connection_lost(self, rsocket):
-        pass
+    async def on_connection_lost(self, rsocket, exception: Exception):
+        await rsocket.close()
 
     async def on_keepalive_timeout(self,
                                    time_since_last_keepalive: timedelta,
-                                   cancel_all_streams: Callable):
+                                   rsocket):
         pass

--- a/rsocket/rsocket.py
+++ b/rsocket/rsocket.py
@@ -33,7 +33,7 @@ class RSocket(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def connect(self):
+    async def connect(self):
         ...
 
     @abc.abstractmethod

--- a/rsocket/rsocket_client.py
+++ b/rsocket/rsocket_client.py
@@ -142,6 +142,3 @@ class RSocketClient(RSocketBase):
             await super()._receiver_listen()
         finally:
             await self._cancel_if_task_exists(keepalive_timeout_task)
-
-    async def _sender(self):
-        return await super()._sender()

--- a/rsocket/rsocket_client.py
+++ b/rsocket/rsocket_client.py
@@ -54,7 +54,6 @@ class RSocketClient(RSocketBase):
 
     async def connect(self):
         logger().debug('%s: connecting', self._log_identifier())
-        self._transport_ready.clear()
 
         if self._current_transport().done():
             await self.close()

--- a/rsocket/rsocket_internal.py
+++ b/rsocket/rsocket_internal.py
@@ -28,3 +28,7 @@ class RSocketInternal(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def send_error(self, stream_id: int, exception: Exception):
         ...
+
+    @abc.abstractmethod
+    def close_all_streams(self):
+        ...

--- a/rsocket/rsocket_server.py
+++ b/rsocket/rsocket_server.py
@@ -1,7 +1,44 @@
+from datetime import timedelta
+from typing import Type, Optional, Union
+
+from reactivestreams.publisher import Publisher
+from rsocket.extensions.mimetypes import WellKnownMimeTypes
+from rsocket.payload import Payload
+from rsocket.request_handler import RequestHandler, BaseRequestHandler
 from rsocket.rsocket_base import RSocketBase
+from rsocket.transports.transport import Transport
 
 
 class RSocketServer(RSocketBase):
+
+    def __init__(self,
+                 transport: Transport,
+                 handler_factory: Type[RequestHandler] = BaseRequestHandler,
+                 honor_lease=False,
+                 lease_publisher: Optional[Publisher] = None,
+                 request_queue_size: int = 0,
+                 data_encoding: Union[str, bytes, WellKnownMimeTypes] = WellKnownMimeTypes.APPLICATION_JSON,
+                 metadata_encoding: Union[str, bytes, WellKnownMimeTypes] = WellKnownMimeTypes.APPLICATION_JSON,
+                 keep_alive_period: timedelta = timedelta(milliseconds=500),
+                 max_lifetime_period: timedelta = timedelta(minutes=10),
+                 setup_payload: Optional[Payload] = None):
+        super().__init__(handler_factory,
+                         honor_lease,
+                         lease_publisher,
+                         request_queue_size,
+                         data_encoding,
+                         metadata_encoding,
+                         keep_alive_period,
+                         max_lifetime_period,
+                         setup_payload)
+        self._transport = transport
+
+    def _current_transport(self) -> Transport:
+        return self._transport
+
+    def _setup_internals(self):
+        self._reset_internals()
+        self._start_tasks()
 
     def _log_identifier(self) -> str:
         return 'server'

--- a/rsocket/rsocket_server.py
+++ b/rsocket/rsocket_server.py
@@ -50,6 +50,3 @@ class RSocketServer(RSocketBase):
 
     def is_server_alive(self) -> bool:
         return True
-
-    async def _sender(self):
-        return await super()._sender()

--- a/rsocket/rsocket_server.py
+++ b/rsocket/rsocket_server.py
@@ -1,4 +1,3 @@
-import asyncio
 from asyncio import Future
 from datetime import timedelta
 from typing import Optional, Union, Callable
@@ -35,7 +34,6 @@ class RSocketServer(RSocketBase):
                          max_lifetime_period,
                          setup_payload)
         self._transport = transport
-        self._transport_ready.set()
 
     def _current_transport(self) -> Future:
         return create_future(self._transport)

--- a/rsocket/rx_support/rx_rsocket.py
+++ b/rsocket/rx_support/rx_rsocket.py
@@ -41,8 +41,8 @@ class RxRSocket:
     def metadata_push(self, metadata: bytes):
         self._rsocket.metadata_push(metadata)
 
-    def connect(self):
-        return self._rsocket.connect()
+    async def connect(self):
+        return await self._rsocket.connect()
 
     async def close(self):
         await self._rsocket.close()

--- a/rsocket/streams/stream_handler.py
+++ b/rsocket/streams/stream_handler.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABCMeta
 from typing import Optional
 
-from rsocket.exceptions import RSocketValueErrorException
+from rsocket.exceptions import RSocketValueError
 from rsocket.frame import Frame, MAX_REQUEST_N
 from rsocket.frame_builders import to_cancel_frame, to_request_n_frame
 from rsocket.logger import logger
@@ -22,7 +22,7 @@ class StreamHandler(BackpressureApi, metaclass=ABCMeta):
     def initial_request_n(self, n: int):
         if n <= 0:
             self.socket.finish_stream(self.stream_id)
-            raise RSocketValueErrorException('Initial request N must be > 0')
+            raise RSocketValueError('Initial request N must be > 0')
 
         self._initial_request_n = n
         return self

--- a/rsocket/transports/aiohttp_websocket.py
+++ b/rsocket/transports/aiohttp_websocket.py
@@ -14,9 +14,9 @@ from rsocket.transports.abstract_websocket import AbstractWebsocketTransport
 @asynccontextmanager
 async def websocket_client(url, *args, **kwargs) -> RSocketClient:
     async def transport_provider():
-        return TransportAioHttpClient(url)
+        yield TransportAioHttpClient(url)
 
-    async with RSocketClient(transport_provider, *args, **kwargs) as client:
+    async with RSocketClient(transport_provider(), *args, **kwargs) as client:
         yield client
 
 

--- a/rsocket/transports/aiohttp_websocket.py
+++ b/rsocket/transports/aiohttp_websocket.py
@@ -13,15 +13,11 @@ from rsocket.transports.abstract_websocket import AbstractWebsocketTransport
 
 @asynccontextmanager
 async def websocket_client(url, *args, **kwargs) -> RSocketClient:
-    async with aiohttp.ClientSession() as session:
-        async with session.ws_connect(url) as ws:
-            transport = TransportAioHttpWebsocket(ws)
-            message_handler = asyncio.create_task(transport.handle_incoming_ws_messages())
-            async with RSocketClient(transport, *args, **kwargs) as client:
-                yield client
+    async def transport_provider():
+        return TransportAioHttpClient(url)
 
-            message_handler.cancel()
-            await message_handler
+    async with RSocketClient(transport_provider, *args, **kwargs) as client:
+        yield client
 
 
 def websocket_handler_factory(*args, on_server_create=None, **kwargs):
@@ -40,10 +36,44 @@ def websocket_handler_factory(*args, on_server_create=None, **kwargs):
     return websocket_handler
 
 
+class TransportAioHttpClient(AbstractWebsocketTransport):
+
+    def __init__(self, url):
+        super().__init__()
+        self._url = url
+
+    async def connect(self):
+        self._session = aiohttp.ClientSession()
+        self._ws_context = self._session.ws_connect(self._url)
+        self._ws = await self._ws_context.__aenter__()
+        self._message_handler = asyncio.create_task(self.handle_incoming_ws_messages())
+
+    async def handle_incoming_ws_messages(self):
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    async for frame in self._frame_parser.receive_data(msg.data, 0):
+                        self._incoming_frame_queue.put_nowait(frame)
+        except asyncio.CancelledError:
+            logger().debug('Asyncio task canceled: aiohttp_handle_incoming_ws_messages')
+
+    async def send_frame(self, frame: Frame):
+        await self._ws.send_bytes(frame.serialize())
+
+    async def close(self):
+        await self._ws_context.__aexit__(None, None, None)
+        await self._session.__aexit__(None, None, None)
+        self._message_handler.cancel()
+        await self._message_handler
+
+
 class TransportAioHttpWebsocket(AbstractWebsocketTransport):
     def __init__(self, websocket):
         super().__init__()
         self._ws = websocket
+
+    async def connect(self):
+        pass
 
     async def handle_incoming_ws_messages(self):
         try:

--- a/rsocket/transports/quart_websocket.py
+++ b/rsocket/transports/quart_websocket.py
@@ -20,6 +20,9 @@ async def websocket_handler(*args, on_server_create=None, **kwargs):
 
 class TransportQuartWebsocket(AbstractWebsocketTransport):
 
+    async def connect(self):
+        pass
+
     async def handle_incoming_ws_messages(self):
         try:
             while True:

--- a/rsocket/transports/quart_websocket.py
+++ b/rsocket/transports/quart_websocket.py
@@ -20,9 +20,6 @@ async def websocket_handler(*args, on_server_create=None, **kwargs):
 
 class TransportQuartWebsocket(AbstractWebsocketTransport):
 
-    async def connect(self):
-        pass
-
     async def handle_incoming_ws_messages(self):
         try:
             while True:

--- a/rsocket/transports/tcp.py
+++ b/rsocket/transports/tcp.py
@@ -11,9 +11,6 @@ class TransportTCP(Transport):
         self._writer = writer
         self._reader = reader
 
-    async def connect(self):
-        pass
-
     async def send_frame(self, frame: Frame):
         with wrap_transport_exception():
             self._writer.write(serialize_with_frame_size_header(frame))

--- a/rsocket/transports/tcp.py
+++ b/rsocket/transports/tcp.py
@@ -11,6 +11,9 @@ class TransportTCP(Transport):
         self._writer = writer
         self._reader = reader
 
+    async def connect(self):
+        pass
+
     async def send_frame(self, frame: Frame):
         self._writer.write(serialize_with_frame_size_header(frame))
 

--- a/rsocket/transports/tcp.py
+++ b/rsocket/transports/tcp.py
@@ -1,7 +1,7 @@
 from asyncio import StreamReader, StreamWriter
 
 from rsocket.frame import Frame, serialize_with_frame_size_header
-from rsocket.logger import logger
+from rsocket.helpers import wrap_transport_exception
 from rsocket.transports.transport import Transport
 
 
@@ -15,24 +15,23 @@ class TransportTCP(Transport):
         pass
 
     async def send_frame(self, frame: Frame):
-        self._writer.write(serialize_with_frame_size_header(frame))
+        with wrap_transport_exception():
+            self._writer.write(serialize_with_frame_size_header(frame))
 
     async def on_send_queue_empty(self):
-        await self._writer.drain()
+        with wrap_transport_exception():
+            await self._writer.drain()
 
     async def close(self):
         self._writer.close()
         await self._writer.wait_closed()
 
     async def next_frame_generator(self, is_server_alive):
-        try:
+        with wrap_transport_exception():
             data = await self._reader.read(1024)
-        except (ConnectionResetError, BrokenPipeError) as exception:
-            logger().debug(str(exception))
-            return  # todo: workaround to silence errors on client closing. this needs a better solution.
 
-        if not data:
-            self._writer.close()
-            return
+            if not data:
+                self._writer.close()
+                return
 
         return self._frame_parser.receive_data(data)

--- a/rsocket/transports/transport.py
+++ b/rsocket/transports/transport.py
@@ -10,6 +10,10 @@ class Transport(metaclass=abc.ABCMeta):
         self._frame_parser = FrameParser()
 
     @abc.abstractmethod
+    async def connect(self):
+        ...
+
+    @abc.abstractmethod
     async def send_frame(self, frame: Frame):
         ...
 

--- a/rsocket/transports/transport.py
+++ b/rsocket/transports/transport.py
@@ -9,9 +9,8 @@ class Transport(metaclass=abc.ABCMeta):
     def __init__(self):
         self._frame_parser = FrameParser()
 
-    @abc.abstractmethod
     async def connect(self):
-        ...
+        """"Optional if required"""
 
     @abc.abstractmethod
     async def send_frame(self, frame: Frame):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,13 @@ from aiohttp.test_utils import RawTestServer
 from quart import Quart
 
 from rsocket.frame_parser import FrameParser
-from rsocket.logger import logger
 from rsocket.rsocket_base import RSocketBase
 from rsocket.rsocket_client import RSocketClient
 from rsocket.rsocket_server import RSocketServer
 from rsocket.transports.aiohttp_websocket import websocket_client, websocket_handler_factory
 from rsocket.transports.quart_websocket import websocket_handler
 from rsocket.transports.tcp import TransportTCP
+from tests.rsocket.helpers import assert_no_open_streams
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -141,16 +141,6 @@ async def pipe_factory_tcp(unused_tcp_port, client_arguments=None, server_argume
         assert_no_open_streams(client, server)
     finally:
         await finish()
-
-
-def assert_no_open_streams(client: RSocketBase, server: RSocketBase):
-    logger().info('Checking for open client streams')
-
-    assert len(client._stream_control._streams) == 0, 'Client has open streams'
-
-    logger().info('Checking for open server streams')
-
-    assert len(server._stream_control._streams) == 0, 'Server has open streams'
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,9 +104,9 @@ async def pipe_factory_tcp(unused_tcp_port, client_arguments=None, server_argume
 
         async def transport_provider():
             connection = await asyncio.open_connection(host, port)
-            return TransportTCP(*connection)
+            yield TransportTCP(*connection)
 
-        client = RSocketClient(transport_provider, **(client_arguments or {}))
+        client = RSocketClient(transport_provider(), **(client_arguments or {}))
 
         if auto_connect_client:
             await client.connect()

--- a/tests/rsocket/helpers.py
+++ b/tests/rsocket/helpers.py
@@ -56,3 +56,7 @@ class IdentifiedHandlerFactory:
 
     def factory(self, socket) -> BaseRequestHandler:
         return self._handler_factory(socket, self._server_id)
+
+
+def force_closing_connection(current_connection):
+    current_connection[1].close()

--- a/tests/rsocket/misbehaving_rsocket.py
+++ b/tests/rsocket/misbehaving_rsocket.py
@@ -3,11 +3,11 @@ from rsocket.transports.transport import Transport
 
 
 class MisbehavingRSocket:
-    def __init__(self, socket: Transport):
-        self._socket = socket
+    def __init__(self, transport: Transport):
+        self._transport = transport
 
     async def send_frame(self, frame: Frame):
-        await self._socket.send_frame(frame)
+        await self._transport.send_frame(frame)
 
 
 class BrokenFrame:

--- a/tests/rsocket/test_connection_lost.py
+++ b/tests/rsocket/test_connection_lost.py
@@ -3,14 +3,16 @@ from asyncio import Event, Future
 from asyncio.base_events import Server
 from typing import Optional, Tuple
 
+from rsocket.frame import Frame
 from rsocket.logger import logger
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
 from rsocket.rsocket_client import RSocketClient
 from rsocket.rsocket_server import RSocketServer
 from rsocket.transports.tcp import TransportTCP
+from rsocket.transports.transport import Transport
 from tests.rsocket.helpers import future_from_payload, IdentifiedHandlerFactory, \
-    IdentifiedHandler
+    IdentifiedHandler, force_closing_connection
 
 
 class ServerHandler(IdentifiedHandler):
@@ -42,15 +44,16 @@ async def test_connection_lost(unused_tcp_port):
         service = await asyncio.start_server(session, host, port)
 
         async def transport_provider():
-            try:
-                nonlocal client_connection
-                client_connection = await asyncio.open_connection(host, port)
-                return TransportTCP(*client_connection)
-            except Exception:
-                logger().error('Client connection error', exc_info=True)
-                raise
+            while True:
+                try:
+                    nonlocal client_connection
+                    client_connection = await asyncio.open_connection(host, port)
+                    yield TransportTCP(*client_connection)
+                except Exception:
+                    logger().error('Client connection error', exc_info=True)
+                    raise
 
-        client = RSocketClient(transport_provider, handler_factory=ClientHandler)
+        client = RSocketClient(transport_provider(), handler_factory=ClientHandler)
 
     service: Optional[Server] = None
     server: Optional[RSocketServer] = None
@@ -78,5 +81,81 @@ async def test_connection_lost(unused_tcp_port):
         service.close()
 
 
-def force_closing_connection(current_connection):
-    current_connection[1].close()
+class FailingTransportTCP(Transport):
+
+    async def connect(self):
+        raise Exception
+
+    async def send_frame(self, frame: Frame):
+        pass
+
+    async def next_frame_generator(self, is_server_alive):
+        pass
+
+    async def close(self):
+        pass
+
+
+async def test_connection_failure(unused_tcp_port):
+    index_iterator = iter(range(1, 3))
+
+    wait_for_server = Event()
+    server_connection: Tuple = None
+    client_connection: Tuple = None
+
+    class ClientHandler(BaseRequestHandler):
+        async def on_connection_lost(self, rsocket, exception: Exception):
+            logger().info('Reconnecting')
+            await rsocket.connect()
+
+    def session(*connection):
+        nonlocal server, server_connection
+        server_connection = connection
+        server = RSocketServer(TransportTCP(*connection),
+                               IdentifiedHandlerFactory(next(index_iterator), ServerHandler).factory)
+        wait_for_server.set()
+
+    async def start():
+        nonlocal service, client
+        service = await asyncio.start_server(session, host, port)
+
+        async def transport_provider():
+            try:
+                nonlocal client_connection
+                client_connection = await asyncio.open_connection(host, port)
+                yield TransportTCP(*client_connection)
+
+                yield FailingTransportTCP()
+
+                client_connection = await asyncio.open_connection(host, port)
+                yield TransportTCP(*client_connection)
+            except Exception:
+                logger().error('Client connection error', exc_info=True)
+                raise
+
+        client = RSocketClient(transport_provider(), handler_factory=ClientHandler)
+
+    service: Optional[Server] = None
+    server: Optional[RSocketServer] = None
+    client: Optional[RSocketClient] = None
+    port = unused_tcp_port
+    host = 'localhost'
+
+    await start()
+
+    try:
+        async with client as connection:
+            await wait_for_server.wait()
+            wait_for_server.clear()
+            response1 = await connection.request_response(Payload(b'request 1'))
+            force_closing_connection(server_connection)
+            await server.close()  # cleanup async tasks from previous server to avoid errors (?)
+            await wait_for_server.wait()
+            response2 = await connection.request_response(Payload(b'request 2'))
+
+            assert response1.data == b'data: request 1 server 1'
+            assert response2.data == b'data: request 2 server 2'
+    finally:
+        await server.close()
+
+        service.close()

--- a/tests/rsocket/test_connection_lost.py
+++ b/tests/rsocket/test_connection_lost.py
@@ -1,0 +1,82 @@
+import asyncio
+from asyncio import Event, Future
+from asyncio.base_events import Server
+from typing import Optional, Tuple
+
+from rsocket.logger import logger
+from rsocket.payload import Payload
+from rsocket.request_handler import BaseRequestHandler
+from rsocket.rsocket_client import RSocketClient
+from rsocket.rsocket_server import RSocketServer
+from rsocket.transports.tcp import TransportTCP
+from tests.rsocket.helpers import future_from_payload, IdentifiedHandlerFactory, \
+    IdentifiedHandler
+
+
+class ServerHandler(IdentifiedHandler):
+    async def request_response(self, payload: Payload) -> Future:
+        return future_from_payload(Payload(payload.data + (' server %d' % self._server_id).encode(), payload.metadata))
+
+
+async def test_connection_lost(unused_tcp_port):
+    index_iterator = iter(range(1, 3))
+
+    wait_for_server = Event()
+    server_connection: Tuple = None
+    client_connection: Tuple = None
+
+    class ClientHandler(BaseRequestHandler):
+        async def on_connection_lost(self, rsocket, exception: Exception):
+            logger().info('Reconnecting')
+            await rsocket.connect()
+
+    def session(*connection):
+        nonlocal server, server_connection
+        server_connection = connection
+        server = RSocketServer(TransportTCP(*connection),
+                               IdentifiedHandlerFactory(next(index_iterator), ServerHandler).factory)
+        wait_for_server.set()
+
+    async def start():
+        nonlocal service, client
+        service = await asyncio.start_server(session, host, port)
+
+        async def transport_provider():
+            try:
+                nonlocal client_connection
+                client_connection = await asyncio.open_connection(host, port)
+                return TransportTCP(*client_connection)
+            except Exception:
+                logger().error('Client connection error', exc_info=True)
+                raise
+
+        client = RSocketClient(transport_provider, handler_factory=ClientHandler)
+
+    service: Optional[Server] = None
+    server: Optional[RSocketServer] = None
+    client: Optional[RSocketClient] = None
+    port = unused_tcp_port
+    host = 'localhost'
+
+    await start()
+
+    try:
+        async with client as connection:
+            await wait_for_server.wait()
+            wait_for_server.clear()
+            response1 = await connection.request_response(Payload(b'request 1'))
+            force_closing_connection(server_connection)
+            await server.close()  # cleanup async tasks from previous server to avoid errors (?)
+            await wait_for_server.wait()
+            response2 = await connection.request_response(Payload(b'request 2'))
+
+            assert response1.data == b'data: request 1 server 1'
+            assert response2.data == b'data: request 2 server 2'
+    finally:
+        await server.close()
+
+        service.close()
+
+
+def force_closing_connection(current_connection):
+    current_connection[1].close()

--- a/tests/rsocket/test_frame.py
+++ b/tests/rsocket/test_frame.py
@@ -2,7 +2,7 @@ import asyncstdlib
 import pytest
 
 from rsocket.error_codes import ErrorCode
-from rsocket.exceptions import RSocketProtocolException
+from rsocket.exceptions import RSocketProtocolError
 from rsocket.extensions.authentication_types import WellKnownAuthenticationTypes
 from rsocket.extensions.composite_metadata import CompositeMetadata
 from rsocket.extensions.mimetypes import WellKnownMimeTypes
@@ -598,5 +598,5 @@ def test_parse_broken_frame_raises_exception():
         bits(13, 23, 'Number of frames to request - broken. smaller than 31 bits'),
     )
 
-    with pytest.raises(RSocketProtocolException):
+    with pytest.raises(RSocketProtocolError):
         parse_or_ignore(broken_frame_data)

--- a/tests/rsocket/test_frame_decode.py
+++ b/tests/rsocket/test_frame_decode.py
@@ -17,12 +17,12 @@ async def test_decode_spring_demo_auth():
     assert authentication.password == b'pass'
 
 
-async def test_multiple_frames(connection):
+async def test_multiple_frames(frame_parser):
     data = b'\x00\x00\x06\x00\x00\x00\x7b\x24\x00'
     data += b'\x00\x00\x13\x00\x00\x26\x6a\x2c\x00\x00\x00\x02\x04\x77\x65\x69'
     data += b'\x72\x64\x6e\x65\x73\x73'
     data += b'\x00\x00\x06\x00\x00\x00\x7b\x24\x00'
     data += b'\x00\x00\x06\x00\x00\x00\x7b\x24\x00'
     data += b'\x00\x00\x06\x00\x00\x00\x7b\x24\x00'
-    frames = await asyncstdlib.builtins.list(connection.receive_data(data))
+    frames = await asyncstdlib.builtins.list(frame_parser.receive_data(data))
     assert len(frames) == 5

--- a/tests/rsocket/test_frame_decode.py
+++ b/tests/rsocket/test_frame_decode.py
@@ -1,5 +1,9 @@
+from typing import cast
+
 import asyncstdlib
 
+from rsocket.extensions.authentication import AuthenticationSimple
+from rsocket.extensions.authentication_content import AuthenticationContent
 from rsocket.extensions.composite_metadata import CompositeMetadata
 
 
@@ -12,7 +16,8 @@ async def test_decode_spring_demo_auth():
 
     assert len(composite_metadata.items) == 2
 
-    authentication = composite_metadata.items[1].authentication
+    composite_item = cast(AuthenticationContent, composite_metadata.items[1])
+    authentication = cast(AuthenticationSimple, composite_item.authentication)
     assert authentication.username == b'user'
     assert authentication.password == b'pass'
 

--- a/tests/rsocket/test_request_response.py
+++ b/tests/rsocket/test_request_response.py
@@ -7,13 +7,13 @@ from rsocket.awaitable.awaitable_rsocket import AwaitableRSocket
 from rsocket.helpers import create_future
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
-from tests.rsocket.helpers import future_from_request
+from tests.rsocket.helpers import future_from_payload
 
 
 async def test_request_response_awaitable_wrapper(pipe):
     class Handler(BaseRequestHandler):
         async def request_response(self, request: Payload):
-            return future_from_request(request)
+            return future_from_payload(request)
 
     server, client = pipe
     server._handler = Handler(server)
@@ -25,7 +25,7 @@ async def test_request_response_awaitable_wrapper(pipe):
 async def test_request_response_repeated(pipe):
     class Handler(BaseRequestHandler):
         async def request_response(self, request: Payload):
-            return future_from_request(request)
+            return future_from_payload(request)
 
     server, client = pipe
     server._handler = Handler(server)

--- a/tests/rsocket/test_request_stream.py
+++ b/tests/rsocket/test_request_stream.py
@@ -8,7 +8,7 @@ from reactivestreams.publisher import Publisher
 from reactivestreams.subscriber import DefaultSubscriber, Subscriber
 from rsocket.awaitable.awaitable_rsocket import AwaitableRSocket
 from rsocket.awaitable.collector_subscriber import CollectorSubscriber
-from rsocket.exceptions import RSocketValueErrorException
+from rsocket.exceptions import RSocketValueError
 from rsocket.frame_helpers import ensure_bytes
 from rsocket.helpers import DefaultPublisherSubscription
 from rsocket.payload import Payload
@@ -52,7 +52,7 @@ async def test_request_stream_prevent_negative_initial_request_n(pipe: Tuple[RSo
                                                                  initial_request_n):
     server, client = pipe
 
-    with pytest.raises(RSocketValueErrorException):
+    with pytest.raises(RSocketValueError):
         client.request_stream(Payload()).initial_request_n(initial_request_n)
 
 

--- a/tests/rsocket/test_resume_unsupported.py
+++ b/tests/rsocket/test_resume_unsupported.py
@@ -15,7 +15,7 @@ from tests.rsocket.misbehaving_rsocket import MisbehavingRSocket
 
 @pytest.mark.allow_error_log
 async def test_setup_resume_unsupported(pipe_tcp_without_auto_connect: Tuple[RSocketServer, RSocketClient]):
-    server, client = pipe_tcp_without_auto_connect
+    _, client = pipe_tcp_without_auto_connect
     received_error_code = None
     error_received = asyncio.Event()
 
@@ -25,7 +25,8 @@ async def test_setup_resume_unsupported(pipe_tcp_without_auto_connect: Tuple[RSo
             received_error_code = error_code
             error_received.set()
 
-    client.set_handler_using_factory(Handler)
+    client.set_handler_factory(Handler)
+    await client.connect()
     bad_client = MisbehavingRSocket(client._transport)
 
     setup = SetupFrame()

--- a/tests/rsocket/test_resume_unsupported.py
+++ b/tests/rsocket/test_resume_unsupported.py
@@ -27,7 +27,8 @@ async def test_setup_resume_unsupported(pipe_tcp_without_auto_connect: Tuple[RSo
 
     client.set_handler_factory(Handler)
     await client.connect()
-    bad_client = MisbehavingRSocket(client._transport)
+    transport = await client._current_transport()
+    bad_client = MisbehavingRSocket(transport)
 
     setup = SetupFrame()
     setup.flags_lease = False
@@ -63,7 +64,8 @@ async def test_resume_request_unsupported(pipe_tcp: Tuple[RSocketServer, RSocket
 
     client.set_handler_using_factory(Handler)
 
-    bad_client = MisbehavingRSocket(client._transport)
+    transport = await client._current_transport()
+    bad_client = MisbehavingRSocket(transport)
 
     resume = ResumeFrame()
     resume.token_length = 1

--- a/tests/rsocket/test_rsocket.py
+++ b/tests/rsocket/test_rsocket.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import pytest
 
 from rsocket.error_codes import ErrorCode
-from rsocket.exceptions import RSocketProtocolException
+from rsocket.exceptions import RSocketProtocolError
 from rsocket.helpers import create_future
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
@@ -55,7 +55,7 @@ async def test_rsocket_max_server_keepalive_reached_and_request_canceled_explici
                 'max_lifetime_period': timedelta(seconds=1),
                 'handler_factory': ClientHandler},
             server_arguments={'handler_factory': Handler}) as (server, client):
-        with pytest.raises(RSocketProtocolException) as exc_info:
+        with pytest.raises(RSocketProtocolError) as exc_info:
             await client.request_response(Payload(b'dog', b'cat'))
 
         assert exc_info.value.data == 'Server not alive'

--- a/tests/rsocket/test_rsocket.py
+++ b/tests/rsocket/test_rsocket.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from datetime import timedelta
-from typing import Callable
 
 import pytest
 
@@ -10,6 +9,7 @@ from rsocket.exceptions import RSocketProtocolException
 from rsocket.helpers import create_future
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
+from rsocket.rsocket_internal import RSocketInternal
 
 
 async def test_rsocket_client_closed_without_requests(lazy_pipe):
@@ -46,8 +46,8 @@ async def test_rsocket_max_server_keepalive_reached_and_request_canceled_explici
 
         async def on_keepalive_timeout(self,
                                        time_since_last_keepalive: timedelta,
-                                       cancel_all_streams: Callable):
-            cancel_all_streams()
+                                       socket: RSocketInternal):
+            socket.close_all_streams()
 
     async with lazy_pipe(
             client_arguments={

--- a/tests/rx_support/test_rx_support.py
+++ b/tests/rx_support/test_rx_support.py
@@ -172,10 +172,12 @@ async def test_rx_rsocket_context_manager(pipe_tcp_without_auto_connect):
         async def request_response(self, payload: Payload) -> Future:
             return create_future(Payload(b'Response'))
 
-    server, client = pipe_tcp_without_auto_connect
-    server.set_handler_using_factory(Handler)
+    server_provider, client = pipe_tcp_without_auto_connect
 
     async with RxRSocket(client) as rx_client:
+        server = await server_provider()
+        server.set_handler_using_factory(Handler)
+
         received_message = await rx_client.request_response(Payload(b'request text')).pipe(
             operators.map(lambda payload: payload.data),
             operators.single()


### PR DESCRIPTION
Reconnect support

### Motivation:

Reconnect support

### Modifications:

Client class now accepts async transport generator instead of single transport
Refactoring connect and close to allow multiple attempts
Client connect method is now async

### Result:

support for reconnection using handler method on_connection_lost
