### PR TITLE
return future from fnf and push metadata methods to be able to await sent frame

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,5 +2,6 @@ Changelog
 ---------
 
 v0.3.1
+======
 
 - Added ability to await fire_and_forget and push_metadata. Waits until the client finishes sending the frame.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,6 @@
+Changelog
+---------
+
+v0.3.1
+
+- Added ability to await fire_and_forget and push_metadata. Waits until the client finishes sending the frame.

--- a/rsocket/frame.py
+++ b/rsocket/frame.py
@@ -1,6 +1,7 @@
 import abc
 import struct
 from abc import ABCMeta
+from asyncio import Future
 from enum import IntEnum, unique
 from typing import Tuple, Optional
 
@@ -86,7 +87,8 @@ class Frame(Header, metaclass=ABCMeta):
         'data',
         'flags_follows',
         'flags_complete',
-        'metadata_only'
+        'metadata_only',
+        'sent_future'
     )
 
     def __init__(self, frame_type: FrameType):
@@ -100,8 +102,9 @@ class Frame(Header, metaclass=ABCMeta):
         self.flags_metadata = False
         self.flags_follows = False
         self.flags_complete = False
-
         self.metadata_only = False
+
+        self.sent_future: Optional[Future] = None
 
     def parse_metadata(self, buffer: bytes, offset: int) -> int:
         if not self.flags_metadata:

--- a/rsocket/frame_builders.py
+++ b/rsocket/frame_builders.py
@@ -6,6 +6,7 @@ from rsocket.frame import (PayloadFrame, RequestNFrame,
                            RequestFireAndForgetFrame, SetupFrame,
                            MetadataPushFrame, KeepAliveFrame,
                            MAX_REQUEST_N)
+from rsocket.helpers import create_future
 from rsocket.payload import Payload
 
 
@@ -69,11 +70,13 @@ def to_request_response_frame(stream_id: int, payload: Payload):
     return request
 
 
-def to_fire_and_forget_frame(stream_id: int, payload: Payload):
+def to_fire_and_forget_frame(stream_id: int, payload: Payload) -> RequestFireAndForgetFrame:
     frame = RequestFireAndForgetFrame()
     frame.stream_id = stream_id
     frame.data = payload.data
     frame.metadata = payload.metadata
+    frame.sent_future = create_future()
+
     return frame
 
 
@@ -95,9 +98,11 @@ def to_setup_frame(payload,
     return setup
 
 
-def to_metadata_push_frame(metadata: bytes):
+def to_metadata_push_frame(metadata: bytes) -> MetadataPushFrame:
     frame = MetadataPushFrame()
     frame.metadata = metadata
+    frame.sent_future = create_future()
+
     return frame
 
 

--- a/rsocket/load_balancer/load_balancer_rsocket.py
+++ b/rsocket/load_balancer/load_balancer_rsocket.py
@@ -21,14 +21,14 @@ class LoadBalancerRSocket(RSocket):
     def request_response(self, payload: Payload) -> Future:
         return self._select_client().request_response(payload)
 
-    def fire_and_forget(self, payload: Payload):
-        self._select_client().fire_and_forget(payload)
+    def fire_and_forget(self, payload: Payload) -> Future:
+        return self._select_client().fire_and_forget(payload)
 
     def request_stream(self, payload: Payload) -> Union[BackpressureApi, Publisher]:
         return self._select_client().request_stream(payload)
 
-    def metadata_push(self, metadata: bytes):
-        self._select_client().metadata_push(metadata)
+    def metadata_push(self, metadata: bytes) -> Future:
+        return self._select_client().metadata_push(metadata)
 
     async def connect(self):
         await self._strategy.connect()

--- a/rsocket/rsocket.py
+++ b/rsocket/rsocket.py
@@ -21,7 +21,7 @@ class RSocket(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def fire_and_forget(self, payload: Payload):
+    def fire_and_forget(self, payload: Payload) -> Future:
         ...
 
     @abc.abstractmethod
@@ -29,7 +29,7 @@ class RSocket(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def metadata_push(self, metadata: bytes):
+    def metadata_push(self, metadata: bytes) -> Future:
         ...
 
     @abc.abstractmethod

--- a/rsocket/rx_support/rx_rsocket.py
+++ b/rsocket/rx_support/rx_rsocket.py
@@ -35,11 +35,11 @@ class RxRSocket:
         ).initial_request_n(request_limit)
         return from_rsocket_publisher(response_publisher, request_limit)
 
-    def fire_and_forget(self, request: Payload):
-        self._rsocket.fire_and_forget(request)
+    def fire_and_forget(self, request: Payload) -> rx.Observable:
+        return rx.from_future(self._rsocket.fire_and_forget(request))
 
-    def metadata_push(self, metadata: bytes):
-        self._rsocket.metadata_push(metadata)
+    def metadata_push(self, metadata: bytes) -> rx.Observable:
+        return rx.from_future(self._rsocket.metadata_push(metadata))
 
     async def connect(self):
         return await self._rsocket.connect()

--- a/tests/rsocket/test_fire_and_forget.py
+++ b/tests/rsocket/test_fire_and_forget.py
@@ -35,6 +35,19 @@ async def test_request_fire_and_forget(lazy_pipe):
         assert handler.received_payload.metadata == b'cat'
 
 
+async def test_request_fire_and_forget_wait(lazy_pipe):
+    handler: Optional[FireAndForgetHandler] = None
+
+    def handler_factory(socket):
+        nonlocal handler
+        handler = FireAndForgetHandler(socket)
+        return handler
+
+    async with lazy_pipe(
+            server_arguments={'handler_factory': handler_factory}) as (server, client):
+        await client.fire_and_forget(Payload(b'dog', b'cat'))
+
+
 async def test_request_fire_and_forget_awaitable_client(lazy_pipe):
     handler: Optional[FireAndForgetHandler] = None
 

--- a/tests/rsocket/test_metadata_push.py
+++ b/tests/rsocket/test_metadata_push.py
@@ -31,12 +31,28 @@ async def test_metadata_push(pipe):
     client: RSocketClient = pipe[1]
     server.set_handler_using_factory(handler_factory)
 
+    # noinspection PyAsyncCall
     client.metadata_push(b'cat')
 
     await handler.received.wait()
 
     assert handler.received_payload.data is None
     assert handler.received_payload.metadata == b'cat'
+
+
+async def test_metadata_push_await(pipe):
+    handler: Optional[MetadataPushHandler] = None
+
+    def handler_factory(socket):
+        nonlocal handler
+        handler = MetadataPushHandler(socket)
+        return handler
+
+    server: RSocketServer = pipe[0]
+    client: RSocketClient = pipe[1]
+    server.set_handler_using_factory(handler_factory)
+
+    await client.metadata_push(b'cat')
 
 
 async def test_metadata_push_awaitable_client(pipe):

--- a/tests/rx_support/test_rx_support.py
+++ b/tests/rx_support/test_rx_support.py
@@ -200,7 +200,7 @@ async def test_rx_support_metadata_push(pipe: Tuple[RSocketServer, RSocketClient
     server.set_handler_using_factory(Handler)
 
     rx_client = RxRSocket(client)
-    rx_client.metadata_push(b'request text')
+    await rx_client.metadata_push(b'request text')
 
     await received_item_event.wait()
 
@@ -221,7 +221,7 @@ async def test_rx_support_fire_and_forget(pipe: Tuple[RSocketServer, RSocketClie
     server.set_handler_using_factory(Handler)
 
     rx_client = RxRSocket(client)
-    rx_client.fire_and_forget(Payload(b'request text'))
+    await rx_client.fire_and_forget(Payload(b'request text'))
 
     await received_item_event.wait()
 

--- a/tests/rx_support/test_rx_support.py
+++ b/tests/rx_support/test_rx_support.py
@@ -200,7 +200,7 @@ async def test_rx_support_metadata_push(pipe: Tuple[RSocketServer, RSocketClient
     server.set_handler_using_factory(Handler)
 
     rx_client = RxRSocket(client)
-    rx_client.metadata_push(b'request text')
+    rx_client.metadata_push(b'request text').run()
 
     await received_item_event.wait()
 
@@ -221,7 +221,7 @@ async def test_rx_support_fire_and_forget(pipe: Tuple[RSocketServer, RSocketClie
     server.set_handler_using_factory(Handler)
 
     rx_client = RxRSocket(client)
-    rx_client.fire_and_forget(Payload(b'request text'))
+    rx_client.fire_and_forget(Payload(b'request text')).run()
 
     await received_item_event.wait()
 

--- a/tests/rx_support/test_rx_support.py
+++ b/tests/rx_support/test_rx_support.py
@@ -200,7 +200,7 @@ async def test_rx_support_metadata_push(pipe: Tuple[RSocketServer, RSocketClient
     server.set_handler_using_factory(Handler)
 
     rx_client = RxRSocket(client)
-    rx_client.metadata_push(b'request text').run()
+    rx_client.metadata_push(b'request text')
 
     await received_item_event.wait()
 
@@ -221,7 +221,7 @@ async def test_rx_support_fire_and_forget(pipe: Tuple[RSocketServer, RSocketClie
     server.set_handler_using_factory(Handler)
 
     rx_client = RxRSocket(client)
-    rx_client.fire_and_forget(Payload(b'request text')).run()
+    rx_client.fire_and_forget(Payload(b'request text'))
 
     await received_item_event.wait()
 


### PR DESCRIPTION
There was no ability to await until the client finished sending the fnf or push metadata requests.

now there is.
